### PR TITLE
new preference to enable/disable update checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+bin

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -197,8 +197,11 @@ MainWindow::MainWindow(QWidget* parent)
   manager = new QNetworkAccessManager(this);
   connect(manager, SIGNAL(finished(QNetworkReply*)), this,
           SLOT(replyFinished(QNetworkReply*)));
-  blAutoCheckUpdate = true;
-  CheckUpdate();
+  // blAutoCheckUpdate = false;
+  if (blAutoCheckUpdate) {
+    CheckUpdate();
+  }
+  
   readINIProxy();
 
   initPlistTextShow();
@@ -217,6 +220,9 @@ void MainWindow::init_iniData() {
 
   defaultIcon = Reg.value("DefaultIcon").toBool();
   ui->actionDefaultNodeIcon->setChecked(defaultIcon);
+
+  blAutoCheckUpdate = Reg.value("EnableAutoUpdate").toBool();
+  ui->actionCheck_Update_Enable->setChecked(blAutoCheckUpdate);
 
   ui->actionExpandAllOpenFile->setChecked(Reg.value("ExpAll").toBool());
 
@@ -1505,6 +1511,7 @@ void MainWindow::closeEvent(QCloseEvent* event) {
     Reg.setValue("frameMainHeight", ui->frameMain->height());
   }
 
+  Reg.setValue("EnableAutoUpdate", blAutoCheckUpdate);
   Reg.setValue("restore", ui->actionRestoreScene->isChecked());
   Reg.setValue("DefaultIcon", ui->actionDefaultNodeIcon->isChecked());
   Reg.setValue("ExpAll", ui->actionExpandAllOpenFile->isChecked());
@@ -2560,6 +2567,8 @@ void MainWindow::on_actionCopy_between_windows_triggered() { on_copyBW(); }
 void MainWindow::on_actionPaste_between_windows_triggered() { on_pasteBW(); }
 
 void MainWindow::on_actionCheck_Update_triggered() { CheckUpdate(); }
+
+void MainWindow::on_actionCheck_Update_Enable_triggered() { blAutoCheckUpdate = ui->actionCheck_Update_Enable->isChecked(); }
 
 void MainWindow::on_actionAbout_triggered() { actionAbout_activated(); }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -255,6 +255,8 @@ class MainWindow : public QMainWindow {
 
   void on_actionCheck_Update_triggered();
 
+  void on_actionCheck_Update_Enable_triggered();
+
   void on_actionAbout_triggered();
 
   void on_actionAdd_triggered();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -892,6 +892,7 @@ QTabBar::tab:left:only-one, QTabBar::tab:right:only-one {
      <addaction name="actProxy4"/>
      <addaction name="actProxy5"/>
     </widget>
+    <addaction name="actionCheck_Update_Enable"/>
     <addaction name="actionCheck_Update"/>
     <addaction name="menuUpgrade_Download_Proxy"/>
     <addaction name="actionDownload_Upgrade_Packages"/>
@@ -1112,6 +1113,14 @@ QStatusBar::item {
    </property>
    <property name="text">
     <string>DefaultNodeIcon</string>
+   </property>
+  </action>
+  <action name="actionCheck_Update_Enable">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Enable or disable update checking</string>
    </property>
   </action>
   <action name="actionCheck_Update">


### PR DESCRIPTION
Hello :) Thank you for coding this great and open source plist editor :+1: 
But I found a minor annoyance. 
In case you have to open PlistEDPlus quite often, close
open, and so on in order to check plist edits, you always have to dismiss 
the automatic update popup message.
So I quickly added a user preference under the Help menu which should allow to optionally
turn update checking off or on.